### PR TITLE
Add plaintext plugin name to discord hook payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ async function handleRequest(request) {
 
 async function sendWebHook(content, name, version, reporter, exception, dhash) {
   let body = {
+    "content": "User feedback: " + name,
     "embeds": [
       {
         "title": "Feedback for " + name,


### PR DESCRIPTION
When replying to a feedback message (not uncommon, I've seen) people pretty much have to click the jump-to-reply-target link to see what feedback is being talked about. This would just add a single normal-text line with the plugin name (which the report window takes automatically, so users can't just post anything in there) so that the reply will show the plugin in question.