### PR TITLE
fix feedback returning 400 error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,9 @@ async function sendWebHook(content, name, version, reporter, exception, dhash, e
 
   let body = {
     "content": `${name}: ${condensed}`,
-    "allowed_mentions": [],
+    "allowed_mentions": {
+      "parse": []
+    },
     "embeds": [
       {
         "title": "Feedback for " + name,


### PR DESCRIPTION
Discord API changed and requires an allowed_mentions object now

<https://discord.com/developers/docs/resources/channel#allowed-mentions-object-allowed-mentions-reference>