### PR TITLE
Block a certain feedback poster

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,13 @@ function isFeedbackSilentlyIgnored(feedbackObject: Feedback) {
   });
 }
 
+const BLOCKED_REPORTER_IDS = [
+  "9fc6526d"
+];
+function isBlockedReporter(reporterId: string) {
+  return BLOCKED_REPORTER_IDS.includes(reporterId);
+}
+
 async function handleRequest(request: Request, env: Env) {
   const reqBody = await readRequestBody(request) as Feedback;
 
@@ -121,6 +128,10 @@ async function handleRequest(request: Request, env: Env) {
   }
 
   let reporterId = await getHashedIp(request, env);
+
+  if (isBlockedReporter(reporterId) {
+    return new Response();
+  }
 
   let res = await sendWebHook(
     reqBody.content,

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,12 @@ const BLOCKED_REPORTER_IDS = [
 ];
 function isBlockedReporter(reporterId: string) {
   return BLOCKED_REPORTER_IDS.includes(reporterId);
+  /***
+  * alternatively, if CF workers support env vars or some other list
+  * we can use NotNite's approach.
+  * const bannedReporters = env.BANNED_REPORTERS.split(",");
+  * return bannedReporters.includes(reporterId);
+  */
 }
 
 async function handleRequest(request: Request, env: Env) {
@@ -129,7 +135,7 @@ async function handleRequest(request: Request, env: Env) {
 
   let reporterId = await getHashedIp(request, env);
 
-  if (isBlockedReporter(reporterId) {
+  if (isBlockedReporter(reporterId)) {
     return new Response();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ async function handleRequest(request: Request, env: Env) {
 
   let reporterId = await getHashedIp(request, env);
 
-  if (isBlockedReporter(reporterId)) {
+  if (reporterId != null && isBlockedReporter(reporterId)) {
     return new Response();
   }
 


### PR DESCRIPTION
We all know who it is and why they should be blocked. 

This is the fastest and laziest method of doing it.

It can be replaced with something better if/when someone wants to implement a better method.